### PR TITLE
Implement load and save feature

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -173,6 +173,10 @@ body {
     display: none;
 }
 
+#load_save {
+    display: none;
+}
+
 #raw_result {
     display: none;
 }
@@ -255,7 +259,7 @@ input[type=text] {
     color: yellow;
 }
 
-#router_list_routers li:hover:not(.selected), #router_list_interfaces li:hover:not(.selected) {
+#saved_queries li:hover:not(.selected), #router_list_routers li:hover:not(.selected), #router_list_interfaces li:hover:not(.selected) {
     background-color: #005c9b;
 }
 
@@ -348,9 +352,13 @@ input[type=text] {
     min-height: 100px;
 }
 
-#router_outer {
+.saved_block, #router_outer {
     overflow: hidden;
     margin-top: 10px;
+}
+
+#load_save input[type=text] {
+    width: 300px;
 }
 
 #router_left {

--- a/static/index.html
+++ b/static/index.html
@@ -73,6 +73,7 @@
                 </p>
                 <p id='final_query'></p>
             </form>
+            <input id='open-load-save' type='button' value='Load / Save'/>
         </div>
     </div>
 
@@ -175,6 +176,28 @@
 </div>
 
 <div class="control-sidebar middle">
+    <div id="load_save" class="control-container">
+        <div class="header_noclick">Load / Save Queries and Options</div>
+        <div class='inner-container_always_expanded'>
+            <div class="saved_block">
+                Saved queries:
+                <ul id="saved_queries"></ul>
+            </div>
+            <div class="saved_block">
+            <input id='load-query' type='button' value='Load selected query'/>
+            <input id='delete-query' type='button' value='Delete selected query'/>
+            <input id='overwrite-query' type='button' value='Overwrite selected query'/>
+            </div>
+            <div class="saved_block">
+                <input id='save-query' type='button' value='Save with name:'/>
+                <input type='text' id='saveName' placeholder='newName'/>
+            </div>
+            <div class="saved_block">
+                <input id='close-load-save' type='button' value='Close'/>
+            </div>
+            </div>
+    </div>
+
     <div id="router_list" class="control-container">
         <div class="header_noclick">Selection</div>
         <div class='inner-container_always_expanded'>

--- a/static/index.html
+++ b/static/index.html
@@ -189,7 +189,11 @@
             <input id='overwrite-query' type='button' value='Overwrite selected query'/>
             </div>
             <div class="saved_block">
-                <input id='save-query' type='button' value='Save with name:'/>
+                <input id='rename-query' type='button' value='Rename selected query to:'/>
+                <input type='text' id='renameName' placeholder='newName'/>
+            </div>
+            <div class="saved_block">
+                <input id='save-query' type='button' value='Save query with name:'/>
                 <input type='text' id='saveName' placeholder='newName'/>
             </div>
             <div class="saved_block">

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -19,7 +19,7 @@ $(document).ready(function () {
 });
 
 function set_sidebar_right_visibility() {
-    if ($("#router_list,#raw_result").is(":visible")) {
+    if ($("#load_save,#router_list,#raw_result").is(":visible")) {
         $("#sidebar_right_with_video").hide(200);
     } else {
         $("#sidebar_right_with_video").show(200);

--- a/static/js/model.js
+++ b/static/js/model.js
@@ -190,7 +190,10 @@ function model_fillGps(data) {
 function show_savedQueries(modelName) {
     $("#saved_queries").empty();
     $("#saved_queries").append(get_saved_queries(modelName).sort().map((queryName) =>
-        $("<li class='saved_queries_query' id='saved_queries_query_" + queryName + "' onclick='set_saved_queries_query(\"" + modelName + "\", \"" + queryName + "\")'>" + queryName + "</li>")));
+        $("<li class='saved_queries_query'>" + queryName + "</li>").prop("id", "saved_queries_query_" + queryName).click(e => 
+            set_saved_queries_query(modelName, queryName)
+        )
+    ));
     $("#load-query,#delete-query,#overwrite-query").prop('disabled', true);
     $("#save-query").prop('disabled', false).off('click').click(e => {
         const queryName = $('#saveName').val();
@@ -203,7 +206,7 @@ function show_savedQueries(modelName) {
 
 function set_saved_queries_query(modelName, queryName) {
     $('.saved_queries_query').removeClass('selected');
-    $('#saved_queries_query_' + queryName.replace(/(:|\.|\[|\]|,|=|@|\/)/g, "\\$1")).addClass('selected');
+    document.getElementById('saved_queries_query_' + queryName).classList.add('selected');
     $("#load-query").prop('disabled', false).off('click').click(e => {
         load_query(modelName, queryName);
     });

--- a/static/js/model.js
+++ b/static/js/model.js
@@ -217,6 +217,13 @@ function set_saved_queries_query(modelName, queryName) {
         save_query(modelName, queryName);
         set_saved_queries_query(modelName, queryName);
     });
+    $("#rename-query").prop('disabled', false).off('click').click(e => {
+        const newQueryName = $('#renameName').val();
+        if (newQueryName) {
+            rename_query(modelName, queryName, newQueryName);
+            set_saved_queries_query(modelName, newQueryName);
+        }
+    });
 }
 
 function get_saved_queries(modelName) {
@@ -271,6 +278,15 @@ function load_query(modelName, queryName) {
 function delete_query(modelName, queryName) {
     let savedQueries = JSON.parse(localStorage.getItem("savedQueries") ?? "{}");
     let savedQueriesForModel = savedQueries[modelName] ?? (savedQueries[modelName] = {});
+    delete savedQueriesForModel[queryName];
+    localStorage.setItem("savedQueries", JSON.stringify(savedQueries));
+    show_savedQueries(modelName);
+}
+
+function rename_query(modelName, queryName, newQueryName) {
+    let savedQueries = JSON.parse(localStorage.getItem("savedQueries") ?? "{}");
+    let savedQueriesForModel = savedQueries[modelName] ?? (savedQueries[modelName] = {});
+    savedQueriesForModel[newQueryName] = savedQueriesForModel[queryName];
     delete savedQueriesForModel[queryName];
     localStorage.setItem("savedQueries", JSON.stringify(savedQueries));
     show_savedQueries(modelName);

--- a/static/js/weight.js
+++ b/static/js/weight.js
@@ -134,3 +134,24 @@ function getWeightList() {
         ).get()]
     ).get();
 }
+
+function restoreWeightList(weightList) {
+    $('#weight_list').empty();
+    if (weightList == null) {
+        const weightGroup = $('#weight_group_template .weight_group').clone(true);
+        weightGroup.appendTo('#weight_list');
+        initializeWeightGroup(weightGroup[0]);
+    } else {
+        weightList.forEach(group => {
+            const weightGroup = $('#weight_group_template .weight_group').clone(true);
+            weightGroup.appendTo('#weight_list');
+            initializeWeightGroup(weightGroup[0]);
+            group.forEach(element => {
+                const weightElement = $('#weight_templates>:contains(' + element.atom + ')').clone();
+                weightElement.children('input').val(element.factor);
+                weightElement.appendTo(weightGroup);
+            });
+        });
+    }
+    weightListChanged();
+}


### PR DESCRIPTION
Implements a Load/Save feature for Queries and Options. Available via the "Load / Save" button in the Query dialog.
The data is stored in localStorage in the browser. So it is separated for every user. Normal browser settings will keep the data with unlimited lifetime.
It saves the query, the validation options and the weight settings. It does not save view settings.
